### PR TITLE
SNI extension is sent whenever SSLContext factory is set. If it is n…

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 -rrequirements.txt
 pytest
+dpkt

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ if sys.hexversion < 0x02070900:
 
 
 setup(name='geventhttpclient',
-      version = '2!1.3.1dev',
+      version = '3!1.3.1dev',
       description = 'http client library for gevent',
       long_description = DESC,
       url="http://github.com/gwik/geventhttpclient",

--- a/src/geventhttpclient/client.py
+++ b/src/geventhttpclient/client.py
@@ -47,16 +47,18 @@ class HTTPClient(object):
             kw.pop('ssl_options', None)
         return cls(url.host, port=url.port, ssl=enable_ssl, **kw)
 
-    def __init__(self, host, port=None, headers={},
-            block_size=BLOCK_SIZE,
-            connection_timeout=ConnectionPool.DEFAULT_CONNECTION_TIMEOUT,
-            network_timeout=ConnectionPool.DEFAULT_NETWORK_TIMEOUT,
-            disable_ipv6=False,
-            concurrency=1,
-            ssl=False, ssl_options=None, ssl_context_factory=None,
-            insecure=False,
-            proxy_host=None, proxy_port=None, version=HTTP_11,
-            headers_type=Headers):
+    def __init__(self, host, port=None, headers=None,
+                 block_size=BLOCK_SIZE,
+                 connection_timeout=ConnectionPool.DEFAULT_CONNECTION_TIMEOUT,
+                 network_timeout=ConnectionPool.DEFAULT_NETWORK_TIMEOUT,
+                 disable_ipv6=False,
+                 concurrency=1,
+                 ssl=False, ssl_options=None, ssl_context_factory=None,
+                 insecure=False,
+                 proxy_host=None, proxy_port=None, version=HTTP_11,
+                 headers_type=Headers):
+        if headers is None:
+            headers = {}
         self.host = host
         self.port = port
         connection_host = self.host
@@ -69,8 +71,8 @@ class HTTPClient(object):
             connection_port = proxy_port
         else:
             self.use_proxy = False
-        if ssl and ssl_options is None:
-            ssl_options = {}
+        if ssl:
+            ssl_options = ssl_options.copy() if ssl_options else {}
         if ssl_options is not None:
             if ssl_context_factory is not None:
                 requested_hostname = headers.get('host', self.host)

--- a/src/geventhttpclient/client.py
+++ b/src/geventhttpclient/client.py
@@ -72,6 +72,9 @@ class HTTPClient(object):
         if ssl and ssl_options is None:
             ssl_options = {}
         if ssl_options is not None:
+            if ssl_context_factory is not None:
+                requested_hostname = headers.get('host', self.host)
+                ssl_options.setdefault('server_hostname', requested_hostname)
             self.ssl = True
             if not self.port:
                 self.port = 443

--- a/src/geventhttpclient/tests/test_ssl.py
+++ b/src/geventhttpclient/tests/test_ssl.py
@@ -1,3 +1,6 @@
+import socket
+
+import dpkt.ssl
 import six
 import sys
 from contextlib import contextmanager
@@ -6,7 +9,12 @@ import gevent.server
 import gevent.socket
 import gevent.ssl
 import os
+
+from gevent import joinall
+
 from geventhttpclient import HTTPClient
+from geventhttpclient.connectionpool import SSLConnectionPool
+
 try:
     from ssl import CertificateError
 except ImportError:
@@ -76,6 +84,102 @@ def test_simple_ssl():
 def timeout_on_connect(sock, addr):
     sock.recv(1024)
     sock.sendall(b'HTTP/1.1 200 Ok\r\nContent-Length: 0\r\n\r\n')
+
+def test_implicit_sni_from_host_in_ssl():
+    server_addr, server_port, sent_sni = _get_sni_sent_from_client()
+    assert sent_sni == server_addr
+
+def test_implicit_sni_from_header_in_ssl():
+    server_addr, server_port, sent_sni = _get_sni_sent_from_client(
+        headers={'host': 'ololo_special_host'},
+    )
+    assert sent_sni == 'ololo_special_host'
+
+def test_explicit_sni_in_ssl():
+    server_addr, server_port, sent_sni = _get_sni_sent_from_client(
+        ssl_options={'server_hostname': 'test_sni'},
+        headers={'host': 'ololo_special_host'},
+    )
+    assert sent_sni == 'test_sni'
+
+def _get_sni_sent_from_client(**additional_client_args):
+    with sni_checker_server() as ctx:
+        server_sock, server_greenlet = ctx
+        server_addr, server_port = server_sock.getsockname()[:2]
+        server_host = socket.gethostbyaddr(server_addr)[0]
+        http = HTTPClient(
+            server_host,
+            server_port,
+            insecure=True,
+            ssl=True,
+            connection_timeout=.1,
+            ssl_context_factory=SSLConnectionPool.ssl_context_factory,
+
+            **additional_client_args,
+        )
+
+        def run(http):
+            with pytest.raises(socket.timeout):
+                response = http.get('/')
+
+        client_greenlet = gevent.spawn(run, http)
+        joinall([client_greenlet, server_greenlet])
+
+    return server_host, server_port, server_greenlet.value
+
+@contextmanager
+def  sni_checker_server():
+    sock = gevent.socket.socket(gevent.socket.AF_INET,
+        gevent.socket.SOCK_STREAM, 0)
+    sock.setsockopt(gevent.socket.SOL_SOCKET, gevent.socket.SO_REUSEADDR, 1)
+    sock.bind(("localhost", 0))
+    sock.listen(1)
+
+    sock.last_seen_sni = None
+
+    def run(sock):
+        while True:
+            conn, addr = sock.accept()
+            client_hello = conn.recv(1024)
+            return extract_sni_from_client_hello(client_hello)
+
+    def extract_sni_from_client_hello(hello_packet: bytes) -> str:
+        records, bytes_used = dpkt.ssl.tls_multi_factory(hello_packet)
+
+        for record in records:
+            # TLS handshake only
+            if record.type != 22:
+                continue
+            if len(record.data) == 0:
+                continue
+            # Client Hello only
+            if record.data[0] != 1:
+                continue
+
+            handshake = dpkt.ssl.TLSHandshake(record.data)
+
+            ch = handshake.data
+
+            SNI_extension = [
+                ext_data
+                for (ext_type, ext_data)
+                in ch.extensions if ext_type == 0x0  # server_name
+            ]
+            if SNI_extension:
+                SNI_extension = SNI_extension[0]
+                sni_list, _ = dpkt.ssl.parse_variable_array(SNI_extension, 2)
+                sni_list = sni_list[1:]  # skip SNI entry type
+                first_entry, _ = dpkt.ssl.parse_variable_array(sni_list, 2)
+
+                return first_entry.decode()
+
+
+    job = gevent.spawn(run, sock)
+    try:
+        yield sock, job
+        sock.close()
+    finally:
+        job.kill()
 
 def test_timeout_on_connect():
     with timeout_connect_server() as listener:

--- a/src/geventhttpclient/tests/test_ssl.py
+++ b/src/geventhttpclient/tests/test_ssl.py
@@ -119,8 +119,10 @@ def _get_sni_sent_from_client(**additional_client_args):
         )
 
         def run(http):
-            with pytest.raises(socket.timeout):
-                response = http.get('/')
+            try:
+                http.get('/')
+            except socket.timeout:
+                pass # handshake will not be completed
 
         client_greenlet = gevent.spawn(run, http)
         joinall([client_greenlet, server_greenlet])


### PR DESCRIPTION
…ot, `wrap_socket()` does not allow this

If explicit `server_hostname` ssl option is specified, it is used as SNI, otherwise the content of the `Host` HTTP header or the host from the requested URL